### PR TITLE
fix swagger doc host and schemes on different envs

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,12 @@ app.use(helmet());
 app.use(hpp());
 
 //api documentation
-app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+app.use("/api-docs", function(req, res, next){
+    swaggerDocument.host = req.get('host');
+    swaggerDocument.schemes = process.env.NODE_ENV === "production" ? ["https"]: ["http"]
+    req.swaggerDoc = swaggerDocument;
+    next();
+}, swaggerUi.serve, swaggerUi.setup())
 
 //all routes
 app.use("/v1", allRoutes)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "nyc": {
     "include": [
+      "controllers",
       "services",
       "test",
       "utils",

--- a/swapiDoc.json
+++ b/swapiDoc.json
@@ -20,7 +20,7 @@
             "description": "Everything about movie comments"
         }
     ],
-    "schemes": ["https", "http"],
+    "schemes": ["https"],
     "consumes": ["application/json"],
     "produces": ["application/json"],
     "paths": {


### PR DESCRIPTION
**What does this PR do?**

Fix Swagger Doc on different environments

**Description of tasks to be completed**

Modify Swagger doc route on app.js

**How to manually test this feature**

Go to "<api_url>/api-docs" to view Swagger documentation and run the endpoints